### PR TITLE
isKosher: add new kosher prefixs

### DIFF
--- a/src/ParsePhone.php
+++ b/src/ParsePhone.php
@@ -88,7 +88,8 @@ class ParsePhone
 
     /** Checks if phone number is Kosher (phone supports only calls) */
     public function isKosher(): bool {
-        return (bool)preg_match('/^0([23489]80|5041|5271|5276|5484|5485|5331|5341|5832|5567)\d{5}$/', $this->phoneNumber);
+        if (!self::isValid()) return false; // if nubmer is not valid - always return false
+        return (bool)preg_match('/^0([23489]80|5041|5271|5276|5484|5485|5331|5341|5832|5567|55410|55400|55401|55402|55760|5532|5552)\d+$/', $this->phoneNumber);
     }
 
     /** Checks if phone number can receive sms */

--- a/tests/Unit/ParsePhoneTest.php
+++ b/tests/Unit/ParsePhoneTest.php
@@ -42,4 +42,141 @@ test('validates an valid israeli phone number as israeli', function () {
     expect($number->isValid())->toBeTrue();
 });
 
+// test kosher and valid numbers for all providers
+test('validates isKosher/isValid numbers', function () {
+    $nonKosherNumbers = [
+        '0527000000',
+        '0522000000',
+        '0548200000',
+        '0555000000',
+        '0505000000',
+        '0554110000',
+        '0504050000',
+        '0507610000',
+        '0512356666',
+        '0526775512',
+        '0534516548',
+        '0546154485',
+        '0548312654',
+        '0555641358',
+        '0554955555',
+        '0586451235',
+        '0795416586',
+        '023549878',
+        '086548745',
+        '0738888888',
+    ];
+
+    foreach ($nonKosherNumbers as $n) {
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for number: $n (got: " . var_export($number->isValid(), true) . ")");
+        expect($number->isKosher())->toBeFalse("isKosher failed for number: $n (got: " . var_export($number->isKosher(), true) . ")");
+    }
+
+    // test invalid numbers
+    $invalidNumbers = [
+        '052760000',
+        '0527164xqwd32',
+        '055410223--000',
+        '0548465666666',
+        '08801111111',
+        '0526987797974'
+    ];
+
+    foreach ($invalidNumbers as $n) {
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeFalse("isValid failed for invalid number: $n (got: " . var_export($number->isValid(), false) . ")");
+        expect($number->isKosher())->toBeFalse("isKosher failed for number: $n (got: " . var_export($number->isKosher(), false) . ")");
+    }
+    
+
+    // 53 - Hot Mobile
+    $n = '0533100000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5567 - Rami Levy
+    $n = '0556700000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5540x - Rami Levy (55400–55402)
+    foreach (['55400', '55401', '55402'] as $p) {
+        $n = '0' . $p . '0000';
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for $n");
+        expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+    }
+
+    // 55760 - Telzar
+    $n = '0557600000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 55410 - Merkazia
+    $n = '0554100000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5041 - Pelephone
+    $n = '0504100000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5832 - Golan
+    $n = '0583200000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5532 - Free Telecom
+    $n = '0553200000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 5552 - Annatel
+    $n = '0555200000';
+    $number = ParsePhone::create($n);
+    expect($number->isValid())->toBeTrue("isValid failed for $n");
+    expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+
+    // 53x - hot mobile
+    foreach (['5331', '5341'] as $p) {
+        $n = '0' . $p . '00000';
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for $n");
+        expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+    }
+
+    // 527x - cellcom
+    foreach (['5276', '5271'] as $p) {
+        $n = '0' . $p . '00000';
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for $n");
+        expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+    }
+
+    // 548x - partner
+    foreach (['5484', '5485'] as $p) {
+        $n = '0' . $p . '00000';
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for $n");
+        expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+    }
+
+    // Bezeq landline: 0280 / 0380 / 0480 / 0980
+    foreach (['0280', '0380', '0480', '0980'] as $p) {
+        $n = $p . '00000';
+        $number = ParsePhone::create($n);
+        expect($number->isValid())->toBeTrue("isValid failed for $n");
+        expect($number->isKosher())->toBeTrue("isKosher failed for $n");
+    }
+});
+
 // TODO add more tests


### PR DESCRIPTION
isKosher: check isValid bafore check regex. add in isKosher new kosher prefixes: annatel,merkazia,telzar,free telecom,rami levvi. add test for all providers.

remove in regex {5}. the kosher number not always in the first 5 digit prefix, Following the MOC allocations of numbering ranges in blocks of 10K